### PR TITLE
xcode-list: Use basename instead of cut

### DIFF
--- a/src/commands/xcode-list
+++ b/src/commands/xcode-list
@@ -48,8 +48,5 @@ find_xcodes() {
 if [ "$full_path" -eq "1" ]; then
   find_xcodes
 else
-  # We know that this doesn't expand the $1 substitution, but since we're using
-  # a function to wrap find, shellcheck doesn't see how it works.
-  # shellcheck disable=SC2016
-  find_xcodes -exec sh -c 'echo "$1" | cut -d"/" -f3 | sed "s/\.app//"' - {} \;
+  find_xcodes -exec basename {} \; | sed 's/\.app//'
 fi


### PR DESCRIPTION
By using `basename` instead of `echo | cut`, we no longer need to use `sh -c` to have `find` execute a pipeline. As a bonus, this also resolves the shellcheck substitution warning.