### PR TITLE
Add xcode-cleanup command

### DIFF
--- a/src/commands/xcode-cleanup
+++ b/src/commands/xcode-cleanup
@@ -1,0 +1,20 @@
+info(){
+  printf "%s\\n" "$1"
+}
+
+usage='xcode-cleanup
+Delete unavailable devices
+
+usage: xcode-cleanup [-h | --help]
+
+  -h | --help           Print this usage documentation and exit
+'
+
+case $1 in
+  --help|-h)
+    info "$usage"
+    exit 0
+    ;;
+esac
+
+xcrun simctl delete unavailable


### PR DESCRIPTION
I frequently run out of disk space 😅

The intention is for this command to grow and delete everything Xcode
doesn't need anymore. For now it deletes unavailable simulators.