### PR TITLE
Handle spaces in PATH

### DIFF
--- a/src/xcode
+++ b/src/xcode
@@ -13,7 +13,7 @@ info(){
 available_commands=$( \
   echo "$PATH" \
   | tr ":" "\n" \
-  | xargs -I {} sh -c 'test -d {} && echo {}' \
+  | xargs -I {} sh -c 'test -d "$@" && echo "$@"' test {} \
   | xargs -I {} find {} -maxdepth 1 -perm +111 -name "xcode-*" \
   | xargs basename \
   )


### PR DESCRIPTION
Using positional arguments to `sh -c` in combination with `"$@"` allows us to avoid improperly escaping paths.