### PR TITLE
Make xcode-nuke delete spm caches

### DIFF
--- a/src/commands/xcode-nuke
+++ b/src/commands/xcode-nuke
@@ -5,18 +5,34 @@ info(){
 }
 
 usage='xcode-nuke
-Deletes Derived Data
+Delete derived data and spm caches.
 
-usage: xcode-nuke [-h | --help]
+usage: xcode-nuke [-h | --help] [-n | --no-spm]
 
-  -h | --help Print this usage documentation and exit
+  -h    |   --help    Print this usage documentation and exit
+  -n    |   --no-spm  Do not clear spm caches
 '
 
+spm=1
 case $1 in
   --help|-h)
     info "$usage"
     exit 0
     ;;
+
+  --no-spm|-n)
+    spm=0
+    shift
+    ;;
 esac
 
+info "rm ~/Library/Developer/Xcode/DerivedData"
 rm -rf ~/Library/Developer/Xcode/DerivedData
+
+if [ "$spm" -eq 1 ]; then
+  info "rm ~/Library/Caches/org.swift.swiftpm"
+  rm -rf ~/Library/Caches/org.swift.swiftpm
+
+  info "rm ~/Library/org.swift.swiftpm"
+  rm -rf ~/library/org.swift.swiftpm
+fi


### PR DESCRIPTION
Considering this is called nuke I expect that by default it deletes everything. `--no-spm` was added in case someone wants to keep SPM caches.